### PR TITLE
Fixed X410 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Unofficial distributions must be installed manually or with tools listed below. 
 
 An X server running on Windows is required for running Linux GUI apps on Windows. See FAQ #9 above.
 
-- [X410](https://afflnk.microsoft.com/c/1291904/433017/7593?u=https%3A%2F%2Fwww.microsoft.com%2Fp%2Fx410%2F9nlp712zmn9q) - X server for Windows 10 on the Microsoft Store. 💰
+- [X410](https://token2shell.com/x410/) - X server for Windows 10 on the Microsoft Store. 💰
 - [VcXsrv](https://sourceforge.net/projects/vcxsrv/) - X server for Windows with hardware acceleration compiled with Visual Studio.
 - [Xmanager](https://www.netsarang.com/en/xmanager/) - X server for Windows from NetSarang. 💰
 - [Xming](https://sourceforge.net/projects/xming/) - An older X server for Windows. Has not been updated since 2016.


### PR DESCRIPTION
Changed the affiliate link to the official website:
* current link is blocked by common ads blockers (uBlock origin)
* users might want to see the official website first

This might be a controversial change depending on the point of view, but in case you don't want to merge this PR I'd heavily suggest you put a disclaimer about affiliate link, or ask GitHub sponsorship for maintenance instead.