### PR TITLE
Add Devuan Linux to distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Unofficial distributions must be installed manually or with tools listed below. 
 - [FedoraWSL](https://github.com/yosukes-dev/FedoraWSL) - Fedora as a WSL distro. ![github project][githublogo]
 - [AmazonWSL](https://github.com/yosukes-dev/AmazonWSL) - Amazon Linux as a WSL distro. ![github project][githublogo]
 - [GentooWSL](https://github.com/ThatWeirdAndrew/GentooWSL) - Gentoo as a WSL distro. ![github project][githublogo]
+- [DevuanWSL](https://github.com/VPraharsha03/DevuanWSL) - Devuan Linux as a WSL Distro. Devuan is a Debian variant without the complexities and dependencies of systemd. ![github project][githublogo]
 
 ## WSL Tools
 


### PR DESCRIPTION
Just wanted to add DevuanWSL distro into the list, devuan is one of the systemd-less distros that provides init freedom to the user