### PR TITLE
Tabby: project rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ An X server running on Windows is required for running Linux GUI apps on Windows
 - [Windows Terminal](https://github.com/microsoft/terminal) - The new open-source Windows Terminal. ![github_project][githublogo]
 - [wsltty](https://github.com/mintty/wsltty) - Mintty as a terminal for WSL. ![github project][githublogo]
 - [wsl-terminal](https://github.com/goreliu/wsl-terminal) - A terminal emulator for WSL, based on mintty, fatty and wslbridge. ![github project][githublogo]
-- [Terminus](https://eugeny.github.io/terminus/) - A terminal for a more modern age. ![github project][githublogo]
+- [Tabby](https://tabby.sh/) - A terminal for a more modern age. ![github project][githublogo]
 - [ConEmu](https://conemu.github.io) - ConEmu aims to be handy, comprehensive, fast and reliable terminal where you may host any console application for the Windows command line, PowerShell, or WSL. 
 - [MobaXterm](https://mobaxterm.mobatek.net) - Enhanced terminal for Windows with X11 server, tabbed SSH client, network tools and much more.
 - [extraterm](https://github.com/sedwards2009/extraterm) - Open source project to build a terminal emulator and expand it with new features to support modern workflows. ![github project][githublogo]


### PR DESCRIPTION
Terminus has been renamed to Tabby: https://github.com/Eugeny/tabby/issues/4088

This PR updates the project name and the URL