### PR TITLE
Add community.wsl.sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ An X server running on Windows is required for running Linux GUI apps on Windows
 
 #### WSL Utilities
 
+- [community.wsl.sdk](https://github.com/Gitii/community.wsl.sdk) - SDK for Windows Subsystem for Linux for .NET 5, 6 and Standard 2.1 ![github project][githublogo]
 - [wslgit](https://github.com/andy-5/wslgit) - Use git installed on WSL from Visual Studio Code on Windows. ![github project][githublogo]
 - [pinentry-wsl-ps1](https://github.com/diablodale/pinentry-wsl-ps1) - Store passwords for gpg-agent in Windows Credential Manager ![github project][githublogo]
 - [wslexec](https://github.com/int128/wslexec) - Execute Linux executables as .exe files on Windows. ![github project][githublogo]

--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ An X server running on Windows is required for running Linux GUI apps on Windows
 
 #### WSL Utilities
 
-- [community.wsl.sdk](https://github.com/Gitii/community.wsl.sdk) - SDK for Windows Subsystem for Linux for .NET 5, 6 and Standard 2.1 ![github project][githublogo]
 - [wslgit](https://github.com/andy-5/wslgit) - Use git installed on WSL from Visual Studio Code on Windows. ![github project][githublogo]
 - [pinentry-wsl-ps1](https://github.com/diablodale/pinentry-wsl-ps1) - Store passwords for gpg-agent in Windows Credential Manager ![github project][githublogo]
 - [wslexec](https://github.com/int128/wslexec) - Execute Linux executables as .exe files on Windows. ![github project][githublogo]
@@ -285,6 +284,7 @@ An X server running on Windows is required for running Linux GUI apps on Windows
 - [vim-wsl-copy-paste](https://github.com/Konfekt/vim-wsl-copy-paste) -  Adds mappings in Vim to write and read on the Windows clipboard.
 . ![github project][githublogo]
 - [WslShortcut](//github.com/HanabishiRecca/WslShortcut) - Run WSL commands directly in Windows. Also allows to use WSL `git`/`node`/etc. in **Visual Studio Code** or another software. Combines functionality of utilities like [`wslgit`](//github.com/andy-5/wslgit), [`wslnodejs`](//github.com/snooopcatt/wslnodejs), [`wslexec`](//github.com/int128/wslexec) etc. with simpler usage. ![github project][githublogo]
+- [community.wsl.sdk](https://github.com/Gitii/community.wsl.sdk) - SDK for Windows Subsystem for Linux for .NET 5, 6 and Standard 2.1 ![github project][githublogo]
 
 #### WSL-Specific Development Tools
 


### PR DESCRIPTION
Hi,

I would like to add my project to this awesome list (to the `WSL Utilities` section):
> [community.wsl.sdk](https://github.com/Gitii/community.wsl.sdk) - SDK for Windows Subsystem for Linux for .NET 5, 6 and Standard 2.1

I saw that there are similar npm packages already (that allow to check for wsl).

best regards