### PR TITLE
Remove ManjaroWSL from list of unofficial distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ Unofficial distributions must be installed manually or with tools listed below. 
 - [AmazonWSL](https://github.com/yosukes-dev/AmazonWSL) - Amazon Linux as a WSL distro. ![github project][githublogo]
 - [GentooWSL](https://github.com/imaandrew/GentooWSL) - Gentoo as a WSL distro. ![github project][githublogo]
 - [DevuanWSL](https://github.com/VPraharsha03/DevuanWSL) - Devuan Linux as a WSL Distro. Devuan is a Debian variant without the complexities and dependencies of systemd. ![github project][githublogo]
-- [ManjaroWSL](https://github.com/sileshn/ManjaroWSL) - Manjaro as a WSL distro based on wsldl. ![github project][githublogo]
 - [WSLackware](https://github.com/Mohsens22/WSLackware) - Slackware as a WSL distro. ![github project][githublogo]
 
 ## WSL Tools


### PR DESCRIPTION
*Manjaro team has issues with using the word "Manjaro" in the title