### PR TITLE
Add ManjaroWSL2 back to list of unofficial distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Unofficial distributions must be installed manually or with tools listed below. 
 - [AmazonWSL](https://github.com/yosukes-dev/AmazonWSL) - Amazon Linux as a WSL distro. ![github project][githublogo]
 - [GentooWSL](https://github.com/imaandrew/GentooWSL) - Gentoo as a WSL distro. ![github project][githublogo]
 - [DevuanWSL](https://github.com/VPraharsha03/DevuanWSL) - Devuan Linux as a WSL Distro. Devuan is a Debian variant without the complexities and dependencies of systemd. ![github project][githublogo]
+- [ManjaroWSL2](https://github.com/sileshn/ManjaroWSL2) - Manjaro as a WSL2 distro based on wsldl. ![github project][githublogo]
 - [WSLackware](https://github.com/Mohsens22/WSLackware) - Slackware as a WSL distro. ![github project][githublogo]
 
 ## WSL Tools


### PR DESCRIPTION
*Received permission from Manjaro core team

This reverts commit e3c2d933a676aaec1ebf3802612d3bd6f9e82a43.