### PR TITLE
Add claude-code-wsl2-setup to WSL-Specific Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ An X server running on Windows is required for running Linux GUI apps on Windows
 #### WSL-Specific Development Tools
 
 - [ghc](https://launchpad.net/~hvr/+archive/ubuntu/ghc-wsl) - A version of the Glasgow Haskell Compiler built and optimized for WSL and hosted in a PPA for Debian and Ubuntu-based WSL distros.
+- [claude-code-wsl2-setup](https://github.com/congmnguyen/claude-code-wsl2-setup) - Documentation and scripts that fix Claude Code (Anthropic's CLI) papercuts on WSL2 + Windows Terminal: screenshot paste via Windows clipboard polling, balloon-tip notifications gated on foreground window, LSP plugin wiring, voice mode via ALSA → PulseAudio → WSLg, and more. ![github project][githublogo]
 
 #### Miscellaneous Tools
 


### PR DESCRIPTION
Adds [claude-code-wsl2-setup](https://github.com/congmnguyen/claude-code-wsl2-setup), an MIT-licensed collection of documentation and install scripts for running Anthropic's Claude Code CLI on WSL2 + Windows Terminal.

It covers WSL2-specific friction:

- Windows clipboard format mismatch on screenshot paste (uses a Go daemon that polls the Windows clipboard and rewrites it so paste returns a WSL path)
- Balloon-tip notifications fired from WSL via PowerShell, gated on the foreground window so they don't fire when Windows Terminal is already focused
- ALSA → PulseAudio → WSLg routing so `/voice` mode can reach the Windows microphone
- LSP plugin wiring for TypeScript, Python, Go, Rust
- Smaller fixes: Shift+Enter newline in Windows Terminal, `BROWSER` env var for OAuth redirects, a custom statusline

Each fix is a standalone markdown doc with the problem, root cause, and exact config.

Inserted under **WSL Tools → WSL-Specific Development Tools**, alphabetically after \`ghc\`, following the existing entry format (markdown link + em-dash description + \`![github project][githublogo]\` badge).