### PR TITLE
Update claude-code-wsl2-setup description

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ An X server running on Windows is required for running Linux GUI apps on Windows
 #### WSL-Specific Development Tools
 
 - [ghc](https://launchpad.net/~hvr/+archive/ubuntu/ghc-wsl) - A version of the Glasgow Haskell Compiler built and optimized for WSL and hosted in a PPA for Debian and Ubuntu-based WSL distros.
-- [claude-code-wsl2-setup](https://github.com/congmnguyen/claude-code-wsl2-setup) - Documentation and scripts that fix Claude Code (Anthropic's CLI) papercuts on WSL2 + Windows Terminal: screenshot paste via Windows clipboard polling, balloon-tip notifications gated on foreground window, LSP plugin wiring, voice mode via ALSA → PulseAudio → WSLg, and more. ![github project][githublogo]
+- [claude-code-wsl2-setup](https://github.com/congmnguyen/claude-code-wsl2-setup) - Claude Code setup for WSL2 + Windows Terminal: Codex delegation, screenshot paste as WSL paths, Windows notifications, LSP wiring, statusline, and safety/context hygiene hooks. ![github project][githublogo]
 
 #### Miscellaneous Tools
 


### PR DESCRIPTION
Updates the existing claude-code-wsl2-setup entry to match the current repo scope. The old description mentioned voice-mode audio, which has been pruned from the main repo; the current setup now focuses on Codex delegation, screenshot paste, Windows notifications, LSP wiring, statusline, and safety/context hygiene hooks.