### PR TITLE
Add wip – a native CLI for Microsoft WSL Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ An X server running on Windows is required for running Linux GUI apps on Windows
 - [xdg-open-wsl](https://github.com/cpbotha/xdg-open-wsl) - xdg-open replacement for WSL that opens files and links using Windows applications. ![github project][githublogo]
 - [gowinbridge](https://github.com/Sibikrish3000/gowinbridge) - A Go library and CLI for executing Windows binaries from WSL. ![github project][githublogo]
 - [Porthole](https://github.com/celloza/porthole) - A native Windows desktop dashboard for WSL Containers with tray-hosted backend operations. ![github project][githublogo]
+- [wip](https://github.com/slidict/wip) - A native CLI that brings dip-like development workflows to Microsoft WSL Containers (WSLC).
 
 #### WSL-Specific Development Tools
 


### PR DESCRIPTION
Adds [wip](https://github.com/slidict/wip), a native CLI for Microsoft WSL Containers (WSLC).

wip provides a Docker Compose / dip-like development workflow for WSLC, with project configuration defined in `wip.yml`. It is distributed as a standalone C# Native AOT executable for Windows.